### PR TITLE
Fix widget docs demo buttons

### DIFF
--- a/apps/www/src/app/layout.tsx
+++ b/apps/www/src/app/layout.tsx
@@ -57,11 +57,6 @@ export default function RootLayout({ children }: { children?: ReactNode }) {
             // font.className
           )}
         >
-          <Script
-            defer
-            src="https://teampilot.ai/widget.js"
-            data-launchpad-slug-id="teampilot-docs-20ee457cee3b099cca3b762da5ca7105"
-          />
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
             <NavigationContextProvider>
               <>

--- a/apps/www/src/app/topics/WidgetShowcase.tsx
+++ b/apps/www/src/app/topics/WidgetShowcase.tsx
@@ -6,6 +6,7 @@ export const WidgetShowcase = () => {
     <>
       <ShowCase
         title="Widget"
+        description="Register browser-side functions with the Teampilot widget and let the assistant call into the host page."
         code={`
 "use client"
 
@@ -14,24 +15,80 @@ import { useEffect, useState } from "react"
 import { z } from "zod"
 import { Button } from "~/shadcn/components/ui/button"
 
+const WIDGET_SCRIPT_ID = "teampilot-widget-local-test"
+const WIDGET_SCRIPT_SRC = "https://teampilot.localhost/widget.js"
+
+const waitForWidgetGlobal = async (): Promise<void> => {
+  for (let i = 0; i < 100; i++) {
+    if ((window as any).teampilot) return
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+  throw new Error("Teampilot widget did not initialize")
+}
+
+const waitForWidget = async (): Promise<void> => {
+  if (typeof window === "undefined") return
+  if ((window as any).teampilot) return
+
+  await new Promise((resolve, reject) => {
+    const existingScript = document.getElementById(WIDGET_SCRIPT_ID)
+    if (existingScript) {
+      resolve(undefined)
+      return
+    }
+
+    const script = document.createElement("script")
+    script.id = WIDGET_SCRIPT_ID
+    script.defer = true
+    script.src = WIDGET_SCRIPT_SRC
+    script.dataset.rememberChatroom = "false"
+    script.dataset.launchpadSlugId =
+      process.env.NEXT_PUBLIC_TEAMPILOT_DEFAULT_LAUNCHPAD_SLUG_ID!
+    script.addEventListener("load", resolve, { once: true })
+    script.addEventListener("error", reject, { once: true })
+    document.body.appendChild(script)
+  })
+
+  await waitForWidgetGlobal()
+}
+
 export const Widget = () => {
   const [color, setColor] = useState("#888888")
 
   useEffect(() => {
-    return teampilotWidget.registerFunction({
-      nameForAI: "changeColor",
-      descriptionForAI: "Change the color of the square using hex codes",
-      inputSchema: z.object({
-        color: z.string(),
-      }),
-      execute: async ({ input }) => {
-        setColor(input.color)
-        return {
-          output: \`Changed color to $\{input.color\}\`,
-        }
-      },
-    })
+    let unregister: (() => void) | undefined
+    let didCancel = false
+
+    void waitForWidget()
+      .then(() => {
+        if (didCancel) return
+        unregister = teampilotWidget.registerFunction({
+          nameForAI: "changeColor",
+          descriptionForAI: "Change the color of the square using hex codes",
+          inputSchema: z.object({
+            color: z.string(),
+          }),
+          execute: async ({ input }) => {
+            setColor(input.color)
+            return {
+              output: \`Changed color to $\{input.color\}\`,
+            }
+          },
+        })
+      })
+      .catch(console.error)
+
+    return () => {
+      didCancel = true
+      unregister?.()
+    }
   }, [])
+
+  const sendWidgetMessage = (message: string) => {
+    void waitForWidget()
+      .then(() => teampilotWidget.sendMessage({ message }))
+      .catch(console.error)
+  }
 
   return (
     <>
@@ -49,9 +106,7 @@ export const Widget = () => {
           variant="outline"
           className="flex-1"
           onClick={() => {
-            teampilotWidget.sendMessage({
-              message: "Make the square blue as the sky",
-            })
+            sendWidgetMessage("Make the square blue as the sky")
           }}
         >
           Blue as the sky
@@ -60,22 +115,12 @@ export const Widget = () => {
           variant="outline"
           className="flex-1"
           onClick={() => {
-            teampilotWidget.sendMessage({
-              message: "Make the square red like a flower",
-            })
+            sendWidgetMessage("Make the square red like a flower")
           }}
         >
           Red like a flower
         </Button>
       </div>
-
-      <script
-        defer
-        src="https://teampilot.ai/widget.js"
-        data-launchpad-slug-id={
-          process.env.NEXT_PUBLIC_TEAMPILOT_DEFAULT_LAUNCHPAD_SLUG_ID!
-        }
-      />
     </>
   )
 }

--- a/apps/www/src/client/MainSideNav.tsx
+++ b/apps/www/src/client/MainSideNav.tsx
@@ -130,7 +130,7 @@ export const MainSideNavMobile = ({}) => {
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
-      <SheetTrigger>
+      <SheetTrigger asChild>
         <Button className="md:hidden" variant={"ghost"} size="icon">
           <Menu />
         </Button>

--- a/apps/www/src/client/examples/Widget.tsx
+++ b/apps/www/src/client/examples/Widget.tsx
@@ -5,24 +5,80 @@ import { useEffect, useState } from "react"
 import { z } from "zod"
 import { Button } from "~/shadcn/components/ui/button"
 
+const WIDGET_SCRIPT_ID = "teampilot-widget-local-test"
+const WIDGET_SCRIPT_SRC = "https://teampilot.localhost/widget.js"
+
+const waitForWidgetGlobal = async (): Promise<void> => {
+  for (let i = 0; i < 100; i++) {
+    if ((window as any).teampilot) return
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+  throw new Error("Teampilot widget did not initialize")
+}
+
+const waitForWidget = async (): Promise<void> => {
+  if (typeof window === "undefined") return
+  if ((window as any).teampilot) return
+
+  await new Promise((resolve, reject) => {
+    const existingScript = document.getElementById(WIDGET_SCRIPT_ID)
+    if (existingScript) {
+      resolve(undefined)
+      return
+    }
+
+    const script = document.createElement("script")
+    script.id = WIDGET_SCRIPT_ID
+    script.defer = true
+    script.src = WIDGET_SCRIPT_SRC
+    script.dataset.rememberChatroom = "false"
+    script.dataset.launchpadSlugId =
+      process.env.NEXT_PUBLIC_TEAMPILOT_DEFAULT_LAUNCHPAD_SLUG_ID!
+    script.addEventListener("load", resolve, { once: true })
+    script.addEventListener("error", reject, { once: true })
+    document.body.appendChild(script)
+  })
+
+  await waitForWidgetGlobal()
+}
+
 export const Widget = () => {
   const [color, setColor] = useState("#888888")
 
   useEffect(() => {
-    return teampilotWidget.registerFunction({
-      nameForAI: "changeColor",
-      descriptionForAI: "Change the color of the square using hex codes",
-      inputSchema: z.object({
-        color: z.string(),
-      }),
-      execute: async ({ input }) => {
-        setColor(input.color)
-        return {
-          output: `Changed color to ${input.color}`,
-        }
-      },
-    })
+    let unregister: (() => void) | undefined
+    let didCancel = false
+
+    void waitForWidget()
+      .then(() => {
+        if (didCancel) return
+        unregister = teampilotWidget.registerFunction({
+          nameForAI: "changeColor",
+          descriptionForAI: "Change the color of the square using hex codes",
+          inputSchema: z.object({
+            color: z.string(),
+          }),
+          execute: async ({ input }) => {
+            setColor(input.color)
+            return {
+              output: `Changed color to ${input.color}`,
+            }
+          },
+        })
+      })
+      .catch(console.error)
+
+    return () => {
+      didCancel = true
+      unregister?.()
+    }
   }, [])
+
+  const sendWidgetMessage = (message: string) => {
+    void waitForWidget()
+      .then(() => teampilotWidget.sendMessage({ message }))
+      .catch(console.error)
+  }
 
   return (
     <>
@@ -40,9 +96,7 @@ export const Widget = () => {
           variant="outline"
           className="flex-1"
           onClick={() => {
-            teampilotWidget.sendMessage({
-              message: "Make the square blue as the sky",
-            })
+            sendWidgetMessage("Make the square blue as the sky")
           }}
         >
           Blue as the sky
@@ -51,22 +105,12 @@ export const Widget = () => {
           variant="outline"
           className="flex-1"
           onClick={() => {
-            teampilotWidget.sendMessage({
-              message: "Make the square red like a flower",
-            })
+            sendWidgetMessage("Make the square red like a flower")
           }}
         >
           Red like a flower
         </Button>
       </div>
-
-      <script
-        defer
-        src="https://teampilot.ai/widget.js"
-        data-launchpad-slug-id={
-          process.env.NEXT_PUBLIC_TEAMPILOT_DEFAULT_LAUNCHPAD_SLUG_ID!
-        }
-      />
     </>
   )
 }


### PR DESCRIPTION
## Summary
- load the local widget script from the docs demo instead of rendering a raw script tag
- keep demo buttons clickable while waiting for widget initialization, then send messages after the widget is ready
- fix mobile nav SheetTrigger button nesting and remove the global production widget script from the docs layout

## Verification
- pnpm --dir apps/www exec tsc --noEmit --pretty false
- pnpm --dir apps/www lint
- headless Chrome check: widget global present, demo buttons enabled, clicking opens widget iframe